### PR TITLE
docs(readme): added node.js example

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ const id = sqids.encode([1, 2, 3]) // "se8ojk"
 const numbers = sqids.decode(id) // [1, 2, 3]
 ```
 
+### Using Sqids in Node.js 
+
+```javascript
+const Sqids = require('sqids').default;
+const sqids = new Sqids({
+    blocklist: new Set(['86Rf07']),
+});
+
+const id = sqids.encode([1, 2, 3]) // "IivTBt"
+const numbers = sqids.decode(id) // [4, 5, 6]
+```
+
 ## 📝 License
 
 [MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ const sqids = new Sqids({
     blocklist: new Set(['86Rf07']),
 });
 
-const id = sqids.encode([1, 2, 3]) // "IivTBt"
+const id = sqids.encode([4, 5, 6]) // "IivTBt"
 const numbers = sqids.decode(id) // [4, 5, 6]
 ```
 


### PR DESCRIPTION
Including the Node.js code snippet directly in the README would be convenient for quick reference. 